### PR TITLE
Добавлена возможность вставлять строки, не заворачивая их в список

### DIFF
--- a/daotestkit/src/main/java/ru/mds/testing/dao/component/DatabaseInitializer.java
+++ b/daotestkit/src/main/java/ru/mds/testing/dao/component/DatabaseInitializer.java
@@ -11,6 +11,7 @@ import ru.mds.testing.dao.model.TableDescription;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -34,6 +35,10 @@ public class DatabaseInitializer {
   public void insertRows(List<Row> rows) {
     String h2script = h2ScriptComposer.composeInsertScripts(rows);
     execute(h2script);
+  }
+
+  public void insertRows(Row... rows) {
+    insertRows(Arrays.asList(rows));
   }
 
   void execute(String query) {


### PR DESCRIPTION
👎 Сейчас в тестах пишут вот так:
```java
databaseInitializer.insertRows( singletonList(row) );
```
или вот так:
```java
databaseInitializer.insertRows( asList(row, anotherRow) );
```
, а еще вот так:
```java
databaseInitializer.insertRows( List.of(row1, row2, row3) );
```
или даже вот так:
```java
 databaseInitializer.insertRows( Lists.newArrayList(rows) );
```
, то есть во всех случаях приходится в явном виде писать обертку в список.

----

👍 А хочется писать проще:
```java
databaseInitializer.insertRows( singleRow );
databaseInitializer.insertRows( row1, row2, row3 );
```

Для этого в класс `ru.mds.testing.dao.component.DatabaseInitializer` добавлен метод с сигнатурой `public void insertRows(Row... rows)`, делегирующий управление исходному методу через обертку в `Arrays.asList()`.